### PR TITLE
Fix building on NixOS

### DIFF
--- a/fnsolver/gui/CMakeLists.txt
+++ b/fnsolver/gui/CMakeLists.txt
@@ -16,6 +16,7 @@ FetchContent_Declare(
     tomlplusplus
     GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
     GIT_TAG v3.4.0
+    FIND_PACKAGE_ARGS
 )
 FetchContent_MakeAvailable(tomlplusplus)
 

--- a/fnsolver/gui/options_loader.cpp
+++ b/fnsolver/gui/options_loader.cpp
@@ -4,6 +4,7 @@
 #include <format>
 #include <toml++/toml.hpp>
 #include <QThread>
+#include <fstream>
 
 Options options_loader::default_options() {
   return {


### PR DESCRIPTION
These small changes fix two roadblocks I hit while attempting to package fnsolver for Nix.

Network access isn't allowed outside using a fetcher so the use of CMake's FetchContent to pull in the tomlplusplus dependency breaks breaks the build. CMake's documentation [revealed an option](https://cmake.org/cmake/help/latest/module/FetchContent.html#integrating-with-find-package) to try using find_package in that FetchContent_Declare invocation.

The second problem is a build issue that I'm not entirely sure why you haven't encountered it when building the Linux release:

```[ 73%] Building CXX object fnsolver/gui/CMakeFiles/fnsolver-gui.dir/options_loader.cpp.o
[ 76%] Building CXX object fnsolver/gui/CMakeFiles/fnsolver-gui.dir/precious_resource_ui.cpp.o
/build/source/fnsolver/gui/options_loader.cpp: In function 'void options_loader::save_to_file(const std::string&, const Options&)':
/build/source/fnsolver/gui/options_loader.cpp:550:29: error: variable 'std::ofstream out' has initializer but incomplete type
  550 |   std::ofstream out(filename);
      |                             ^
/build/source/fnsolver/gui/options_loader.cpp:7:1: note: 'std::ofstream' is defined in header '<fstream>'; this is probably fixable by adding '#include <fstream>'
    6 | #include <QThread>
  +++ |+#include <fstream>
    7 | 
make[2]: *** [fnsolver/gui/CMakeFiles/fnsolver-gui.dir/build.make:477: fnsolver/gui/CMakeFiles/fnsolver-gui.dir/options_loader.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:382: fnsolver/gui/CMakeFiles/fnsolver-gui.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

The suggested change was literally all that was needed to satisfy the compiler.

If you happen to have a Nix environment that you'd like to try reproducing here is the WIP package.nix (I'm using the nixos-unstable branch):

```
{
  stdenv,
  lib,
  cmake,
  libGL,
  qt6,
  fetchFromGitHub,
  tomlplusplus
}:


  stdenv.mkDerivation rec {
    pname = "fnsolver";
    version = "1.1.1";
    outputs = [ "out" ];

    src = fetchFromGitHub {
      owner = "Strasedon";
      repo = "fnsolver";
      rev = "9644aebf8eb9a29a163413523da0235b0fb6b700";
      hash = "sha256-4s2yGn8vg1PdA8iYzHxkppzL4yu4dOejBkcWiKIu25Q=";
    };

#    src = fetchFromGitHub {
#       owner = "beta382";
#       repo = "fnsolver";
#       tag = "${version}";
#       hash = "sha256-68jw8YaAe1GoeBZgaQtiJ98S0JtCBZUE3qayi6KZJFA=";
#     };


    nativeBuildInputs = [ cmake tomlplusplus libGL qt6.qtbase qt6.qtsvg qt6.qttools qt6.wrapQtAppsHook ];

    meta = {
      description = "FnSolver is a tool for the video games Xenoblade Chronicles X and Xenoblade Chronicles X: Definitive Edition, which generates tailored solutions to FrontierNav layouts.";
      homepage = "https://github.com/beta382/fnsolver";
      maintainers = [];
      licenses = [ lib.licenses.mit lib.licenses.bsd3 ];
    };
  }
```
Run with `nix-build --expr '(import <nixpkgs> {}).callPackage ./package.nix {}'`, you can change the commented out blocks to see the build failure.